### PR TITLE
Update to use more generic interfaces

### DIFF
--- a/src/Monolog/Formatter/MongoDBFormatter.php
+++ b/src/Monolog/Formatter/MongoDBFormatter.php
@@ -57,9 +57,9 @@ class MongoDBFormatter implements FormatterInterface
     {
         if ($this->maxNestingLevel == 0 || $nestingLevel <= $this->maxNestingLevel) {
             foreach ($record as $name => $value) {
-                if ($value instanceof \DateTime) {
+                if ($value instanceof \DateTimeInterface) {
                     $record[$name] = $this->formatDate($value, $nestingLevel + 1);
-                } elseif ($value instanceof \Exception) {
+                } elseif ($value instanceof \Throwable) {
                     $record[$name] = $this->formatException($value, $nestingLevel + 1);
                 } elseif (is_array($value)) {
                     $record[$name] = $this->formatArray($value, $nestingLevel + 1);
@@ -82,7 +82,7 @@ class MongoDBFormatter implements FormatterInterface
         return $this->formatArray($objectVars, $nestingLevel);
     }
 
-    protected function formatException(\Exception $exception, $nestingLevel)
+    protected function formatException(\Throwable $exception, $nestingLevel)
     {
         $formattedException = array(
             'class' => get_class($exception),
@@ -100,7 +100,7 @@ class MongoDBFormatter implements FormatterInterface
         return $this->formatArray($formattedException, $nestingLevel);
     }
 
-    protected function formatDate(\DateTime $value, $nestingLevel)
+    protected function formatDate(\DateTimeInterface $value, $nestingLevel)
     {
         $seconds = (int) $value->format('U');
         $milliseconds = (int) $value->format('u') / 1000;


### PR DESCRIPTION
I saw that your branch was already a PR on the main repo, so I thought to just make this small change here for you. PHP 7 can throw Errors and Exceptions, so use `Throwable` interface. `DateTimeInterface` allows for both `DateTime` and `DateTimeImmutable`.
